### PR TITLE
Fix No space between title description and form #46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Versions
 ## [1.3.1] - 05.02.2022
 
-* Updated form_part.dat to fix Bug #45, SixedBox height when spacingWithoutSocial is null or zero.
+* Updated form_part.dat to fix Bug #46, SixedBox height when spacingWithoutSocial is null or zero.
 
 ## [1.3.0] - 28.01.2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Versions
+## [1.3.1] - 05.02.2022
+
+* Updated form_part.dat to fix Bug #45, SixedBox height when spacingWithoutSocial is null or zero.
+
 ## [1.3.0] - 28.01.2022
 
 * Loading indicators are integrated to the buttons instead of dialogs.

--- a/lib/src/widgets/form_part.dart
+++ b/lib/src/widgets/form_part.dart
@@ -211,7 +211,7 @@ class __FormPartState extends State<_FormPart> {
             else
               SizedBox(
                 height:
-                  (loginTheme.spacingWithoutSocial!.compareTo(0) > 0
+                  (loginTheme.spacingWithoutSocial != null && loginTheme.spacingWithoutSocial!.compareTo(0) > 0
                          ? loginTheme.spacingWithoutSocial : dynamicSize.height * 2),
               ),
             _form,

--- a/lib/src/widgets/form_part.dart
+++ b/lib/src/widgets/form_part.dart
@@ -211,7 +211,8 @@ class __FormPartState extends State<_FormPart> {
             else
               SizedBox(
                 height:
-                    loginTheme.spacingWithoutSocial ?? dynamicSize.height * 6,
+                  (loginTheme.spacingWithoutSocial!.compareTo(0) > 0
+                         ? loginTheme.spacingWithoutSocial : dynamicSize.height * 2),
               ),
             _form,
             SizedBox(height: loginTheme.spacingFormAndAction ?? _customSpace),


### PR DESCRIPTION
Fixed the SizedBox height logic when `spacingWithoutSocial` is set to 0 and `socialLogins` is empty.