### PR TITLE
Inoperative Initial Mode Parameter

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,8 +59,8 @@ class _LoginScreenState extends State<LoginScreen> {
   /// Example selected language, default is English.
   LanguageOption language = _languageOptions[1];
 
-  /// Current auth mode, default is [AuthMode.login].
-  AuthMode currentMode = AuthMode.login;
+  /// Current auth mode, default is [AuthMode.signup].
+  AuthMode currentMode = AuthMode.signup;
 
   CancelableOperation? _operation;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -59,8 +59,8 @@ class _LoginScreenState extends State<LoginScreen> {
   /// Example selected language, default is English.
   LanguageOption language = _languageOptions[1];
 
-  /// Current auth mode, default is [AuthMode.signup].
-  AuthMode currentMode = AuthMode.signup;
+  /// Current auth mode, default is [AuthMode.login].
+  AuthMode currentMode = AuthMode.login;
 
   CancelableOperation? _operation;
 

--- a/lib/animated_login.dart
+++ b/lib/animated_login.dart
@@ -501,7 +501,7 @@ class __ViewState extends State<_View> with SingleTickerProviderStateMixin {
       case LoginComponents.form:
         return _mobileWrapper(component.animationType, const _Form());
       case LoginComponents.forgotPassword:
-        return context.select<Auth, bool>((Auth auth) => auth.isReverse)
+        return context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin)
             ? _mobileWrapper(component.animationType, const _ForgotPassword())
             : Container();
       case LoginComponents.actionButton:

--- a/lib/src/providers/auth.dart
+++ b/lib/src/providers/auth.dart
@@ -48,6 +48,7 @@ class Auth extends ChangeNotifier {
     _onSignup = onSignup ?? _defaultSignupFunc;
     _onForgotPassword = onForgotPassword ?? _defaultForgotPassFunc;
     _mode = initialMode ?? AuthMode.login;
+    _initialMode = initialMode ?? AuthMode.login;
   }
 
   /// Default login, signup and forgot password functions to be
@@ -78,6 +79,7 @@ class Auth extends ChangeNotifier {
   final List<SocialLogin>? socialLogins;
 
   late AuthMode _mode;
+  late AuthMode _initialMode;
 
   /// Current authentication mode of the screen.
   AuthMode get mode => _mode;
@@ -98,17 +100,18 @@ class Auth extends ChangeNotifier {
 
   /// Switches the authentication mode and notify the listeners.
   AuthMode switchAuth() {
-    if (mode == AuthMode.login) {
-      notifySetMode(AuthMode.signup);
-    } else if (mode == AuthMode.signup) {
-      notifySetMode(AuthMode.login);
-    }
+    notifySetMode(isLogin ? AuthMode.signup : AuthMode.login);
     if (onAuthModeChange != null) onAuthModeChange!(mode);
     return mode;
   }
 
+  bool _isReverse = true;
+
   /// Indicates whether the screen animation is reverse mode.
-  bool isReverse = true;
+  bool get isReverse => _isReverse;
+
+  /// Combination of isReverse and initial mode values.
+  bool get isAnimatedLogin => !_isReverse ^ (_initialMode == AuthMode.login);
 
   /// Username in the text controller.
   String? username;
@@ -137,8 +140,8 @@ class Auth extends ChangeNotifier {
 
   /// Sets the confirm password.
   void setIsReverse(bool newValue) {
-    if (newValue != isReverse) {
-      isReverse = newValue;
+    if (newValue != _isReverse) {
+      _isReverse = newValue;
       notifyListeners();
     }
   }

--- a/lib/src/widgets/form_part.dart
+++ b/lib/src/widgets/form_part.dart
@@ -35,7 +35,7 @@ class __WebFormState extends State<_WebForm> {
   late final Animation<double> offsetAnimation;
 
   late bool _isLandscape;
-  late bool _isReverse;
+  late bool _isAnimatedLogin;
 
   @override
   void initState() {
@@ -65,7 +65,8 @@ class __WebFormState extends State<_WebForm> {
     dynamicSize = DynamicSize(context);
     loginTheme = context.watch<LoginTheme>();
     _isLandscape = loginTheme.isLandscape;
-    _isReverse = context.select<Auth, bool>((Auth auth) => auth.isReverse);
+    _isAnimatedLogin =
+        context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin);
     loginTexts = context.read<LoginTexts>();
     theme = Theme.of(context);
     auth = context.read<Auth>();
@@ -122,7 +123,7 @@ class __WebFormState extends State<_WebForm> {
       case LoginComponents.form:
         return <Widget>[const _Form()];
       case LoginComponents.forgotPassword:
-        return <Widget>[if (_isReverse) const _ForgotPassword()];
+        return <Widget>[if (_isAnimatedLogin) const _ForgotPassword()];
       case LoginComponents.actionButton:
         return <Widget>[const _ActionButton()];
       default:
@@ -154,15 +155,14 @@ class _ActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final LoginTheme loginTheme = context.watch<LoginTheme>();
     final LoginTexts loginTexts = context.read<LoginTexts>();
-    final bool isReverse =
-        context.select<Auth, bool>((Auth auth) => auth.isReverse);
+    final bool isAnimatedLogin =
+        context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin);
     final bool isLandscape = loginTheme.isLandscape;
     return Padding(
       padding: loginTheme.actionButtonPadding ??
-          EdgeInsets.symmetric(
-              vertical: _customSpace(context, isReverse, isLandscape)),
+          EdgeInsets.symmetric(vertical: _customSpace(context, isLandscape)),
       child: RoundedButton(
-        buttonText: isReverse ? loginTexts.login : loginTexts.signUp,
+        buttonText: isAnimatedLogin ? loginTexts.login : loginTexts.signUp,
         onPressed: context.read<Auth>().action,
         backgroundColor: isLandscape
             ? Theme.of(context).primaryColor.withOpacity(.8)
@@ -172,7 +172,7 @@ class _ActionButton extends StatelessWidget {
     );
   }
 
-  double _customSpace(BuildContext context, bool isReverse, bool isLandscape) {
+  double _customSpace(BuildContext context, bool isLandscape) {
     double factor = 2;
     if (isLandscape) {
       factor = 3;
@@ -191,7 +191,7 @@ class _FormTitle extends StatelessWidget {
     return Padding(
       padding: loginTheme.formTitlePadding ?? EdgeInsets.zero,
       child: BaseText(
-        context.select<Auth, bool>((Auth auth) => auth.isReverse)
+        context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin)
             ? loginTexts.loginFormTitle
             : loginTexts.signUpFormTitle,
         style: TextStyles(context)
@@ -252,7 +252,7 @@ class _UseEmailText extends StatelessWidget {
   Widget _useEmailText(BuildContext context, LoginTheme loginTheme) {
     final LoginTexts loginTexts = context.read<LoginTexts>();
     return BaseText(
-      context.select<Auth, bool>((Auth auth) => auth.isReverse)
+      context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin)
           ? loginTexts.loginUseEmail
           : loginTexts.signUpUseEmail,
       style: TextStyles(context)
@@ -305,10 +305,10 @@ class _FormState extends State<_Form> {
 
   List<Widget> _formElements(Auth auth, LoginTheme loginTheme) {
     final LoginTexts loginTexts = context.read<LoginTexts>();
-    final bool isReverse =
-        context.select<Auth, bool>((Auth auth) => auth.isReverse);
+    final bool isAnimatedLogin =
+        context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin);
     return <Widget>[
-      if (!isReverse && auth.signUpMode != SignUpModes.confirmPassword)
+      if (!isAnimatedLogin && auth.signUpMode != SignUpModes.confirmPassword)
         CustomTextFormField(
           controller: auth.nameController,
           hintText: loginTexts.nameHint,
@@ -348,7 +348,7 @@ class _FormState extends State<_Form> {
         onChanged: auth.setPassword,
         validator: auth.passwordValidator,
       ),
-      if (!isReverse && auth.signUpMode != SignUpModes.name)
+      if (!isAnimatedLogin && auth.signUpMode != SignUpModes.name)
         ObscuredTextFormField(
           controller: auth.confirmPasswordController,
           hintText: loginTexts.confirmPasswordHint,

--- a/lib/src/widgets/welcome_components.dart
+++ b/lib/src/widgets/welcome_components.dart
@@ -12,7 +12,7 @@ class _Title extends StatelessWidget {
       padding: loginTheme.titlePadding ??
           EdgeInsets.symmetric(vertical: DynamicSize(context).height * .8),
       child: BaseText(
-        context.select<Auth, bool>((Auth auth) => auth.isReverse)
+        context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin)
             ? loginTexts.welcomeBack
             : loginTexts.welcome,
         style: TextStyles(context)
@@ -36,7 +36,7 @@ class _Description extends StatelessWidget {
               vertical: DynamicSize(context).height *
                   (loginTheme.isLandscape ? 3 : 2)),
       child: NotFittedText(
-        context.select<Auth, bool>((Auth auth) => auth.isReverse)
+        context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin)
             ? loginTexts.welcomeBackDescription
             : loginTexts.welcomeDescription,
         style: TextStyles(context)
@@ -82,9 +82,10 @@ class _ChangeActionButton extends StatelessWidget {
     final LoginTexts loginTexts = context.read<LoginTexts>();
     final LoginTheme loginTheme = context.read<LoginTheme>();
     return RoundedButton(
-      buttonText: context.select<Auth, bool>((Auth auth) => auth.isReverse)
-          ? loginTexts.signUp
-          : loginTexts.login,
+      buttonText:
+          context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin)
+              ? loginTexts.signUp
+              : loginTexts.login,
       onPressed: animate,
       borderColor: Colors.white,
       backgroundColor: Theme.of(context).primaryColor.withOpacity(.8),
@@ -128,7 +129,7 @@ class _ChangeActionTitle extends StatelessWidget {
 
   Widget _changeActionTitle(BuildContext context, LoginTexts loginTexts) =>
       BaseText(
-        context.select<Auth, bool>((Auth auth) => auth.isReverse)
+        context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin)
             ? loginTexts.notHaveAnAccount
             : loginTexts.alreadyHaveAnAccount,
         style: TextStyles(context)
@@ -148,7 +149,7 @@ class _ChangeActionTitle extends StatelessWidget {
   Widget _changeActionText(BuildContext context) {
     final LoginTexts loginTexts = context.read<LoginTexts>();
     return BaseText(
-      context.select<Auth, bool>((Auth auth) => auth.isReverse)
+      context.select<Auth, bool>((Auth auth) => auth.isAnimatedLogin)
           ? loginTexts.signUp
           : loginTexts.login,
       style: TextStyles(context)


### PR DESCRIPTION
- Fixed the initial mode parameter which doesn't set the initial mode correctly
- Added "isAnimatedLogin" field to the Auth provider to check both the animation status and the login status simultaneously.
- Created a private "_initialMode" field inside the Auth provider to store the initial mode preference for further checks.

Closes #62 